### PR TITLE
Add basic TLS-Scanner wrapper and scan core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # Custom
+TLS-Scanner/
+tls/
 *venv*/
 .vscode/
 results/

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ Also, Grinder can show you some basic information:
 ![Grinder Map 2](/docs/map_2.png?raw=true "Grinder Map 2")
 ## Requirements
 - [Python 3.6+](https://www.python.org/downloads/)
-- [Shodan](https://account.shodan.io/register) and [Censys](https://account.shodan.io/register) accounts
-- [Nmap Security Scanner](https://nmap.org/download.html)
+- [Shodan](https://account.shodan.io/register) and [Censys](https://account.shodan.io/register) accounts (free or pro)
+- [Nmap Security Scanner 7.60+](https://nmap.org/download.html)
+- [TLS-Attacker](https://github.com/RUB-NDS/TLS-Attacker)
+- [TLS-Scanner](https://github.com/RUB-NDS/TLS-Scanner)
 ## Current Features
  - [Grinder Development Project](https://github.com/sdnewhop/grinder/projects/2?fullscreen=true)  
  

--- a/README.md
+++ b/README.md
@@ -23,39 +23,60 @@ Also, Grinder can show you some basic information:
 ![Grinder Map 2](/docs/map_2.png?raw=true "Grinder Map 2")
 ## Requirements
 - [Python 3.6+](https://www.python.org/downloads/)
-- [Shodan](https://account.shodan.io/register) and [Censys](https://account.shodan.io/register) accounts (free or pro)
-- [Nmap Security Scanner 7.60+](https://nmap.org/download.html)
-- [TLS-Attacker](https://github.com/RUB-NDS/TLS-Attacker)
-- [TLS-Scanner](https://github.com/RUB-NDS/TLS-Scanner)
+- [Shodan](https://account.shodan.io/register) and [Censys](https://account.shodan.io/register) accounts  
+Required to collect hosts, both free and full accounts are suitable. Also, it's possible to use only one account (Censys or Shodan, Shodan is preferable).
+- [Nmap Security Scanner 7.60+](https://nmap.org/download.html)  
+Version 7.60 and newer has been tested with currently used in Grinder scripts (ssl-cert.nse, vulners.nse, etc.).
+- [TLS-Attacker](https://github.com/RUB-NDS/TLS-Attacker)  
+Required only for TLS scanning. Version 3.0 has been tested.
+- [TLS-Scanner](https://github.com/RUB-NDS/TLS-Scanner)  
+Required only for TLS scanning.
 ## Current Features
+### Already implemented
+- Collecting hosts and additional information using Shodan and Censys search engines
+- Scanning ports and services with boosted multiprocessed Nmap Scanner wrapper
+- Scanning vulnerabilities and additional information about them with Vulners database and Shodan CVEs database
+- Retrieving information about SSL certificates
+- Scanning for SSL/TLS configuration and supported ciphersuites
+- Scanning for SSL/TLS bugs, vulnerabilities and attacks
+- Building an interactive map with information about the hosts found
+- Creating plots and tables based on the collected results
+- Custom scanning scripts support (in LUA or Python3)
+- Confidence filtering system support
+- Special vendors scanning and filtering support
+
+### Development and future updates
  - [Grinder Development Project](https://github.com/sdnewhop/grinder/projects/2?fullscreen=true)  
  
 The Grinder framework is still in progress and got features to improve, so all the tasks and other features will always be described in this project. If you got some awesome ideas or any other interesting things for Grinder, you can always open a pull request or some issues in this repository.
 ## Setup and Configure Environment
-1. Clone the repository
+1. Install [Nmap Security Scanner](https://nmap.org/download.html), if not installed.
+2. Clone the repository
 ```
 git clone https://github.com/sdnewhop/grinder
 ```
-2. Create virtual environment
+3. Clone and install [TLS-Attacker](https://github.com/RUB-NDS/TLS-Attacker).
+4. Clone [TLS-Scanner](https://github.com/RUB-NDS/TLS-Scanner) in directory with Grinder and install it.
+5. Create virtual environment
 ```
 cd grinder
 python3 -m venv grindervenv
 source grindervenv/bin/activate
 ```
-3. Check if virtual environment successfully loaded
+6. Check if virtual environment successfully loaded
 ```
 which python
 which pip
 ```
-4. Install project requirements in virtual environment
+7. Install project requirements in virtual environment
 ```
 pip3 install -r requirements.txt
 ```
-5. Run the script
+8. Run the script
 ```
 ./grinder.py -h
 ```
-6. Set your Shodan and Censys keys via a command line argument
+9. Set your Shodan and Censys keys via a command line argument
 ```
 ./grinder.py -sk YOUR_SHODAN_KEY -ci YOUR_CENSYS_ID -cs YOUR_CENSYS_SECRET
 ```
@@ -65,7 +86,7 @@ export SHODAN_API_KEY=YOUR_SHODAN_API_KEY_HERE
 export CENSYS_API_ID=YOUR_CENSYS_API_ID_HERE
 export CENSYS_API_SECRET=YOUR_CENSYS_API_SECRET_HERE
 ```
-7. Deactivate virtual environment after use and restore default python interpreter
+10. Deactivate virtual environment after use and restore default python interpreter
 ```
 deactivate
 ```

--- a/grinder.py
+++ b/grinder.py
@@ -57,6 +57,7 @@ if __name__ == "__main__":
         )
     if args.script_check:
         core.run_scripts(queries_filename=args.queries_file)
+    core.tls_scan()
     if args.count_unique:
         core.count_unique_entities("product")
         core.count_unique_entities("vendor")

--- a/grinder.py
+++ b/grinder.py
@@ -55,9 +55,10 @@ if __name__ == "__main__":
             host_timeout=args.host_timeout,
             workers=args.nmap_workers,
         )
+    if args.tls_scan:
+        core.tls_scan()
     if args.script_check:
         core.run_scripts(queries_filename=args.queries_file)
-    core.tls_scan()
     if args.count_unique:
         core.count_unique_entities("product")
         core.count_unique_entities("vendor")

--- a/grinder.py
+++ b/grinder.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
             workers=args.nmap_workers,
         )
     if args.tls_scan:
-        core.tls_scan()
+        core.tls_scan(args.tls_scan_path)
     if args.script_check:
         core.run_scripts(queries_filename=args.queries_file)
     if args.count_unique:

--- a/grinder/core.py
+++ b/grinder/core.py
@@ -58,6 +58,7 @@ from grinder.utils import GrinderUtils
 from grinder.pyscriptexecutor import PyScriptExecutor
 from grinder.nmapscriptexecutor import NmapScriptExecutor
 from grinder.tlsscanner import TlsScanner
+from grinder.tlsparser import TlsParser
 
 
 class HostInfo(NamedTuple):
@@ -802,10 +803,32 @@ class GrinderCore:
             **self.censys_processed_results,
         }
         tls_scanner = TlsScanner(self.combined_results)
-        tls_scanner.sort_alive_hosts()
-        tls_scanner.detect_tls_ports()
-        tls_scanner.link_alive_hosts_with_tls_ports()
-        tls_scanner.start_tls_scan()
+        tls_parser = TlsParser(self.combined_results)
+        try:
+            tls_scanner.sort_alive_hosts()
+        except Exception as sort_alive_hosts_err:
+            print(f"Error at TLS scanner sort alive hosts method: {sort_alive_hosts_err}")
+            return
+        try:
+            tls_scanner.detect_tls_ports()
+        except Exception as detect_tls_ports_err:
+            print(f"Error at detecting of TLS ports method: {detect_tls_ports_err}")
+            return
+        try:
+            tls_scanner.link_alive_hosts_with_tls_ports()
+        except Exception as link_alive_hosts_with_tls_ports_err:
+            print(f"Error at linking hosts with ports in TLS method: {link_alive_hosts_with_tls_ports_err}")
+            return
+        try:
+            tls_scanner.start_tls_scan()
+        except Exception as tls_scan_err:
+            print(f"Error at TLS scanning: {tls_scan_err}")
+            return
+        try:
+            tls_parser.load_tls_scan_results()
+        except Exception as parse_tls_results_err:
+            print(f"Error at TLS results parsing: {parse_tls_results_err}")
+            return
 
     @exception_handler(expected_exception=GrinderCoreNmapScanError)
     def nmap_scan(

--- a/grinder/core.py
+++ b/grinder/core.py
@@ -795,7 +795,7 @@ class GrinderCore:
         }
 
     @exception_handler(expected_exception=GrinderCoreTlsScanner)
-    def tls_scan(self):
+    def tls_scan(self, scanner_path):
         cprint("Start TLS scanning", "blue", attrs=["bold"])
         if not self.shodan_processed_results:
             self.shodan_processed_results = self.db.load_last_shodan_results()
@@ -839,7 +839,10 @@ class GrinderCore:
             return
         try:
             cprint("Run TLS-Scanner", "blue", attrs=["bold"])
-            tls_scanner.start_tls_scan()
+            if scanner_path:
+                tls_scanner.start_tls_scan(scanner_path=scanner_path)
+            else:
+                tls_scanner.start_tls_scan()
         except Exception as tls_scan_err:
             print(f"Error at TLS scanning: {tls_scan_err}")
             return

--- a/grinder/core.py
+++ b/grinder/core.py
@@ -796,6 +796,7 @@ class GrinderCore:
 
     @exception_handler(expected_exception=GrinderCoreTlsScanner)
     def tls_scan(self):
+        cprint("Start TLS scanning", "blue", attrs=["bold"])
         if not self.shodan_processed_results:
             self.shodan_processed_results = self.db.load_last_shodan_results()
         if not self.censys_processed_results:
@@ -807,6 +808,9 @@ class GrinderCore:
         tls_scanner = TlsScanner(self.combined_results)
         tls_parser = TlsParser(self.combined_results)
         try:
+            cprint(
+                "Checking for currently online and alive hosts", "blue", attrs=["bold"]
+            )
             tls_scanner.sort_alive_hosts()
         except Exception as sort_alive_hosts_err:
             print(
@@ -814,11 +818,19 @@ class GrinderCore:
             )
             return
         try:
+            cprint(
+                "Detect SSL/TLS ports, certificates and services",
+                "blue",
+                attrs=["bold"],
+            )
             tls_scanner.detect_tls_ports()
         except Exception as detect_tls_ports_err:
             print(f"Error at detecting of TLS ports method: {detect_tls_ports_err}")
             return
         try:
+            cprint(
+                "Link compatible ports and services with hosts", "blue", attrs=["bold"]
+            )
             tls_scanner.link_alive_hosts_with_tls_ports()
         except Exception as link_alive_hosts_with_tls_ports_err:
             print(
@@ -826,11 +838,13 @@ class GrinderCore:
             )
             return
         try:
+            cprint("Run TLS-Scanner", "blue", attrs=["bold"])
             tls_scanner.start_tls_scan()
         except Exception as tls_scan_err:
             print(f"Error at TLS scanning: {tls_scan_err}")
             return
         try:
+            cprint("Parse and process TLS-Scanner results", "blue", attrs=["bold"])
             tls_parser.load_tls_scan_results()
         except Exception as parse_tls_results_err:
             print(f"Error at TLS results parsing: {parse_tls_results_err}")

--- a/grinder/core.py
+++ b/grinder/core.py
@@ -15,7 +15,11 @@ from grinder.censysconnector import CensysConnector
 from grinder.continents import GrinderContinents
 from grinder.dbhandling import GrinderDatabase
 from grinder.decorators import exception_handler, timer
-from grinder.defaultvalues import DefaultValues, DefaultNmapScanValues, DefaultVulnersScanValues
+from grinder.defaultvalues import (
+    DefaultValues,
+    DefaultNmapScanValues,
+    DefaultVulnersScanValues,
+)
 from grinder.errors import (
     GrinderCoreSearchError,
     GrinderCoreBatchSearchError,
@@ -128,9 +132,7 @@ class GrinderCore:
         """
 
         # Skip default values
-        if (
-            self.shodan_api_key == "YOUR_DEFAULT_API_KEY"
-        ):
+        if self.shodan_api_key == "YOUR_DEFAULT_API_KEY":
             print(f"│ Shodan key is not defined. Skip scan.")
             print(f"└ ", end="")
             return []
@@ -807,7 +809,9 @@ class GrinderCore:
         try:
             tls_scanner.sort_alive_hosts()
         except Exception as sort_alive_hosts_err:
-            print(f"Error at TLS scanner sort alive hosts method: {sort_alive_hosts_err}")
+            print(
+                f"Error at TLS scanner sort alive hosts method: {sort_alive_hosts_err}"
+            )
             return
         try:
             tls_scanner.detect_tls_ports()
@@ -817,7 +821,9 @@ class GrinderCore:
         try:
             tls_scanner.link_alive_hosts_with_tls_ports()
         except Exception as link_alive_hosts_with_tls_ports_err:
-            print(f"Error at linking hosts with ports in TLS method: {link_alive_hosts_with_tls_ports_err}")
+            print(
+                f"Error at linking hosts with ports in TLS method: {link_alive_hosts_with_tls_ports_err}"
+            )
             return
         try:
             tls_scanner.start_tls_scan()

--- a/grinder/decorators.py
+++ b/grinder/decorators.py
@@ -3,7 +3,7 @@
 import sys
 from functools import wraps
 from os import path, makedirs, system
-from time import time
+from time import time, strftime, gmtime
 
 
 def exception_handler(expected_exception):
@@ -60,7 +60,8 @@ def timer(function):
         start = time()
         result = function(*args, **kwargs)
         end = time()
-        print(f"Done in {round(end - start, 2)}s")
+        seconds = round(end - start, 2)
+        print(f"Done in {seconds}s ({str(strftime('%M:%S', gmtime(seconds)))})")
         return result
 
     return wrapper

--- a/grinder/decorators.py
+++ b/grinder/decorators.py
@@ -12,7 +12,6 @@ def exception_handler(expected_exception):
             try:
                 return function(*args, **kwargs)
             except KeyboardInterrupt:
-                print("Keyboard Interrupt Detected. Operation aborted. Bye!")
                 system("stty sane")
                 sys.exit(1)
             except SystemExit:

--- a/grinder/defaultvalues.py
+++ b/grinder/defaultvalues.py
@@ -34,6 +34,10 @@ class DefaultValues:
     PNG_LIMITED_RESULTS_DIRECTORY: str = "limited_results"
 
 
+class DefaultTlsParserValues:
+    ATTACKS_JSON = "tls_scanner_results.json"
+
+
 class DefaultTlsScannerValues:
     LENGTH_OF_HOSTS_SUBGROUPS = 5
     NMAP_PING_SCAN_ARGS = "-n -sP -PE --max-retries=1"

--- a/grinder/defaultvalues.py
+++ b/grinder/defaultvalues.py
@@ -34,6 +34,44 @@ class DefaultValues:
     PNG_LIMITED_RESULTS_DIRECTORY: str = "limited_results"
 
 
+class DefaultTlsScannerValues:
+    LENGTH_OF_HOSTS_SUBGROUPS = 5
+    NMAP_PING_SCAN_ARGS = "-n -sP -PE --max-retries=1"
+    TLS_DETECTION_HOST_TIMEOUT = 60
+    SSL_NMAP_SCRIPT_PATH = "/plugins/ssl-cert.nse"
+    TLS_SCANNER_REPORT_DETAIL = "NORMAL"
+    TLS_SCANNER_SCAN_DETAIL = "NORMAL"
+    TLS_SCANNER_PATH = "./TLS-Scanner/apps/TLS-Scanner.jar"
+    TLS_SCANNER_THREADS = 4
+    TLS_SCANNER_RESULTS_DIR = "tls"
+    TLS_SCANNER_TIMEOUT = 1200
+
+
+class DefaultVulnersScanValues:
+    SUDO = False
+    PORTS = None
+    TOP_PORTS = None
+    WORKERS = 10
+    HOST_TIMEOUT = 120
+    VULNERS_SCRIPT_PATH = "/plugins/vulners.nse"
+
+
+class DefaultNmapScanValues:
+    PORTS = None
+    TOP_PORTS = None
+    SUDO = False
+    HOST_TIMEOUT = 30
+    ARGUMENTS = "-Pn -T4 -A"
+    WORKERS = 10
+
+
+class DefaultProcessManagerValues:
+    PORTS = None
+    SUDO = False
+    ARGUMENTS = "-Pn -A"
+    WORKERS = 10
+
+
 class DefaultPlotValues:
     PLOT_DEFAULT_AUTOPCT = "%1.1f%%"
     PLOT_LABEL_FONT_SIZE = 6

--- a/grinder/errors.py
+++ b/grinder/errors.py
@@ -296,6 +296,9 @@ class GrinderCoreNmapScanError(GrinderCoreException):
     def __init__(self, error_args: Exception):
         super().__init__(error_args)
 
+class GrinderCoreTlsScanner(GrinderCoreException):
+    def __init__(self, error_args: Exception):
+        super().__init__(error_args)
 
 class GrinderCoreFilterQueriesError(GrinderCoreException):
     def __init__(self, error_args: Exception):

--- a/grinder/errors.py
+++ b/grinder/errors.py
@@ -296,9 +296,11 @@ class GrinderCoreNmapScanError(GrinderCoreException):
     def __init__(self, error_args: Exception):
         super().__init__(error_args)
 
+
 class GrinderCoreTlsScanner(GrinderCoreException):
     def __init__(self, error_args: Exception):
         super().__init__(error_args)
+
 
 class GrinderCoreFilterQueriesError(GrinderCoreException):
     def __init__(self, error_args: Exception):

--- a/grinder/filemanager.py
+++ b/grinder/filemanager.py
@@ -72,7 +72,9 @@ class GrinderFileManager:
                 results_to_write = GrinderFileManager.csv_dict_fix(
                     results_to_write, csv_file
                 )
-            writer = DictWriter(result_csv_file, fieldnames=results_to_write[0].keys())
+
+            maximum_fields = max(results_to_write, key=len)
+            writer = DictWriter(result_csv_file, fieldnames=maximum_fields.keys())
             writer.writeheader()
             for row in results_to_write:
                 writer.writerow(row)

--- a/grinder/interface.py
+++ b/grinder/interface.py
@@ -194,7 +194,7 @@ class GrinderInterface:
             "--tls-scan",
             action="store_true",
             default=False,
-            help="Check for possible TLS attacks and bugs (require TLS-Scanner)"
+            help="Check for possible TLS attacks and bugs (require TLS-Scanner)",
         )
 
         self.args = parser.parse_args()

--- a/grinder/interface.py
+++ b/grinder/interface.py
@@ -196,6 +196,13 @@ class GrinderInterface:
             default=False,
             help="Check for possible TLS attacks and bugs (require TLS-Scanner)",
         )
+        parser.add_argument(
+            "-tsp",
+            "--tls-scan-path",
+            action="store",
+            default=None,
+            help="Path to TLS-Scanner.jar (if TLS-Scanner directory not in Grinder root, else not required)"
+        )
 
         self.args = parser.parse_args()
         if not self.args.shodan_key:

--- a/grinder/interface.py
+++ b/grinder/interface.py
@@ -189,6 +189,14 @@ class GrinderInterface:
             default=False,
             help="Show more information",
         )
+        parser.add_argument(
+            "-ts",
+            "--tls-scan",
+            action="store_true",
+            default=False,
+            help="Check for possible TLS attacks and bugs (require TLS-Scanner)"
+        )
+
         self.args = parser.parse_args()
         if not self.args.shodan_key:
             self.args.shodan_key = self.load_shodan_key_from_env()

--- a/grinder/nmapprocessmanager.py
+++ b/grinder/nmapprocessmanager.py
@@ -56,12 +56,12 @@ class NmapProcessing(Process):
 
 class NmapProcessingManager:
     def __init__(
-        self, 
-        hosts: list, 
-        ports=DefaultProcessManagerValues.PORTS, 
-        sudo=DefaultProcessManagerValues.SUDO, 
-        arguments=DefaultProcessManagerValues.ARGUMENTS, 
-        workers=DefaultProcessManagerValues.WORKERS
+        self,
+        hosts: list,
+        ports=DefaultProcessManagerValues.PORTS,
+        sudo=DefaultProcessManagerValues.SUDO,
+        arguments=DefaultProcessManagerValues.ARGUMENTS,
+        workers=DefaultProcessManagerValues.WORKERS,
     ):
         self.hosts = hosts
         self.workers = workers

--- a/grinder/nmapprocessmanager.py
+++ b/grinder/nmapprocessmanager.py
@@ -9,6 +9,7 @@ from grinder.errors import (
     NmapProcessingManagerOrganizeProcessesError,
 )
 from grinder.nmapconnector import NmapConnector
+from grinder.defaultvalues import DefaultProcessManagerValues
 
 
 class NmapProcessingResults:
@@ -55,7 +56,12 @@ class NmapProcessing(Process):
 
 class NmapProcessingManager:
     def __init__(
-        self, hosts: list, ports=None, sudo=False, arguments="-Pn -A", workers=5
+        self, 
+        hosts: list, 
+        ports=DefaultProcessManagerValues.PORTS, 
+        sudo=DefaultProcessManagerValues.SUDO, 
+        arguments=DefaultProcessManagerValues.ARGUMENTS, 
+        workers=DefaultProcessManagerValues.WORKERS
     ):
         self.hosts = hosts
         self.workers = workers

--- a/grinder/nmapprocessmanager.py
+++ b/grinder/nmapprocessmanager.py
@@ -30,14 +30,15 @@ class NmapProcessing(Process):
             index, hosts_quantity, host = self.queue.get()
             host_ip = host.get("ip")
             host_port = str(host.get("port"))
-            if not self.ports:
-                print(
-                    f" ■ Current scan host ({index}/{hosts_quantity}): {host_ip}:{host_port}"
-                )
+
+            port_postfix = "Default"
+            if not self.ports and host_port:
+                port_postfix = host_port
             if self.ports:
-                print(
-                    f" ■ Current scan host ({index}/{hosts_quantity}): {host_ip}:{str(self.ports)}"
-                )
+                port_postfix = str(self.ports)
+            print(
+                f"⭕ Current scan host ({index}/{hosts_quantity}): {host_ip}:{port_postfix}"
+            )
             nm = NmapConnector()
             nm.scan(
                 host=host_ip,

--- a/grinder/tlsparser.py
+++ b/grinder/tlsparser.py
@@ -87,7 +87,9 @@ class TlsParser:
                 results = host_tls_results.read()
 
                 attacks, bugs = self._parse_attacks(results)
-                search_pattern = findall(r"(\d+.\d+.\d+.\d+)-(\d+)-(\w+)-(.+).txt", file)
+                search_pattern = findall(
+                    r"(\d+.\d+.\d+.\d+)-(\d+)-(\w+)-(.+).txt", file
+                )
                 if not search_pattern:
                     continue
                 ip, port, vendor, product = search_pattern[0]
@@ -119,7 +121,7 @@ class TlsParser:
         self,
         results,
         dest_dir: str = DefaultValues.RESULTS_DIRECTORY,
-        filename: str = DefaultTlsParserValues.ATTACKS_JSON
+        filename: str = DefaultTlsParserValues.ATTACKS_JSON,
     ):
         full_path = Path(".").joinpath(dest_dir).joinpath(filename)
         with open(full_path, "w") as alive_hosts:

--- a/grinder/tlsparser.py
+++ b/grinder/tlsparser.py
@@ -59,8 +59,6 @@ class TlsParser:
                 continue
             if attack_res[0] == "true":
                 attacks.update({attack: True})
-            elif attack_res[0] == "false":
-                attacks.update({attack: False})
 
         bugs = {}
         for bug in LIST_OF_BUGS:
@@ -69,8 +67,6 @@ class TlsParser:
                 continue
             if bug_res[0] == "true":
                 bugs.update({bug: True})
-            elif bug_res[0] == "false":
-                bugs.update({attack: False})
 
         return attacks, bugs
 

--- a/grinder/tlsparser.py
+++ b/grinder/tlsparser.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+from os import listdir
+from re import findall
+from json import dump
+from pprint import pprint
+from pathlib import Path
+from grinder.defaultvalues import (
+    DefaultValues,
+    DefaultTlsScannerValues,
+    DefaultTlsParserValues,
+)
+
+LIST_OF_ATTACKS = [
+    "Padding Oracle",
+    "Bleichenbacher",
+    "CRIME",
+    "Breach",
+    "Invalid Curve",
+    "Invalid Curve Ephemerals",
+    "SSL Poodle",
+    "TLS Poodle",
+    "CVE-20162107",
+    "Logjam",
+    "Sweet 32",
+    "DROWN",
+    "Heartbleed",
+    "EarlyCcs",
+]
+
+LIST_OF_BUGS = [
+    "Version Intolerant",
+    "Ciphersuite Intolerant",
+    "Extension Intolerant",
+    "CS Length Intolerant \(>512 Byte\)",
+    "Compression Intolerant",
+    "ALPN Intolerant",
+    "CH Length Intolerant",
+    "NamedGroup Intolerant",
+    "Empty last Extension Intolerant",
+    "SigHashAlgo Intolerant",
+    "Big ClientHello Intolerant",
+    "2nd Ciphersuite Byte Bug",
+    "Ignores offered Ciphersuites",
+    "Reflects offered Ciphersuites",
+    "Ignores offered NamedGroups",
+    "Ignores offered SigHashAlgos",
+]
+
+
+class TlsParser:
+    def __init__(self, hosts: dict):
+        self.hosts: dict = hosts
+
+    def _parse_attacks(self, results: str) -> (dict, dict):
+        attacks = {}
+        for attack in LIST_OF_ATTACKS:
+            attack_res = findall(r"{attack}\s+: (\w+)".format(attack=attack), results)
+            if not attack_res:
+                continue
+            if attack_res[0] == "true":
+                attacks.update({attack: True})
+            elif attack_res[0] == "false":
+                attacks.update({attack: False})
+
+        bugs = {}
+        for bug in LIST_OF_BUGS:
+            bug_res = findall(r"{bug}\s+: (\w+)".format(bug=bug), results)
+            if not bug_res:
+                continue
+            if bug_res[0] == "true":
+                bugs.update({bug: True})
+            elif bug_res[0] == "false":
+                bugs.update({attack: False})
+
+        return attacks, bugs
+
+    def load_tls_scan_results(
+        self,
+        dest_dir: str = DefaultValues.RESULTS_DIRECTORY,
+        tls_dir: str = DefaultTlsScannerValues.TLS_SCANNER_RESULTS_DIR,
+    ) -> None:
+        all_results = {}
+        full_path = Path(".").joinpath(dest_dir).joinpath(tls_dir)
+
+        for file in listdir(full_path):
+            with open(full_path.joinpath(file), mode="r") as host_tls_results:
+                results = host_tls_results.read()
+
+                attacks, bugs = self._parse_attacks(results)
+                search_pattern = findall(r"(\d+.\d+.\d+.\d+)-(\d+)-(\w+)-(.+).txt", file)
+                if not search_pattern:
+                    continue
+                ip, port, vendor, product = search_pattern[0]
+                vendor = vendor.replace("_", " ")
+                product = product.replace("_", " ")
+
+                if not all_results.get(ip):
+                    all_results.update(
+                        {
+                            ip: dict(
+                                vendor=vendor,
+                                product=product,
+                                port=port,
+                                attacks=attacks,
+                                bugs=bugs,
+                            )
+                        }
+                    )
+
+                if self.hosts.get(ip):
+                    if attacks:
+                        self.hosts[ip].update(dict(attacks=attacks))
+                    if bugs:
+                        self.hosts[ip].update(dict(bugs=bugs))
+
+        self.save_results(all_results)
+
+    def save_results(
+        self,
+        results,
+        dest_dir: str = DefaultValues.RESULTS_DIRECTORY,
+        filename: str = DefaultTlsParserValues.ATTACKS_JSON
+    ):
+        full_path = Path(".").joinpath(dest_dir).joinpath(filename)
+        with open(full_path, "w") as alive_hosts:
+            try:
+                dump(results, alive_hosts, indent=4)
+            except:
+                raise Exception("Can not save hosts to json file")

--- a/grinder/tlsscanner.py
+++ b/grinder/tlsscanner.py
@@ -12,16 +12,18 @@ from re import compile
 
 
 class TlsScanner:
-    def __init__(self, hosts: dict, n: int = DefaultTlsScannerValues.LENGTH_OF_HOSTS_SUBGROUPS):
+    def __init__(
+        self, hosts: dict, n: int = DefaultTlsScannerValues.LENGTH_OF_HOSTS_SUBGROUPS
+    ):
         self.hosts: dict = hosts
         self.alive_hosts: list = []
         self.tls_ports: dict = {}
         self.all_ports: dict = {}
         self.alive_hosts_with_ports: dict = {}
         self.n: int = n
-    
+
     def _grouper(self, n, iterable, padding=None):
-        return zip_longest(*[iter(iterable)]*n, fillvalue=padding)
+        return zip_longest(*[iter(iterable)] * n, fillvalue=padding)
 
     def _set_ping_status(self):
         for ip, host_info in self.hosts.items():
@@ -40,23 +42,29 @@ class TlsScanner:
             print(f"Pingscan for {self.n} hosts from group {index}/{groups_len}")
             group_ips = [ip for ip in group if ip]
             hosts_in_nmap_format = " ".join(group_ips)
-            nm.scan(hosts=hosts_in_nmap_format, 
-                    arguments=DefaultTlsScannerValues.NMAP_PING_SCAN_ARGS)
+            nm.scan(
+                hosts=hosts_in_nmap_format,
+                arguments=DefaultTlsScannerValues.NMAP_PING_SCAN_ARGS,
+            )
             results = nm.all_hosts()
-            alive_hosts_group = [ip for ip in results if nm[ip]["status"]["state"] == "up"]
+            alive_hosts_group = [
+                ip for ip in results if nm[ip]["status"]["state"] == "up"
+            ]
             groups[index] = alive_hosts_group
         groups_flat = [host for group in groups for host in group]
         self.alive_hosts = groups_flat
         self._set_ping_status()
 
-    def detect_tls_ports(self, 
-                         ssl_script_path: str = DefaultTlsScannerValues.SSL_NMAP_SCRIPT_PATH,
-                         host_timeout: int = DefaultTlsScannerValues.TLS_DETECTION_HOST_TIMEOUT):
+    def detect_tls_ports(
+        self,
+        ssl_script_path: str = DefaultTlsScannerValues.SSL_NMAP_SCRIPT_PATH,
+        host_timeout: int = DefaultTlsScannerValues.TLS_DETECTION_HOST_TIMEOUT,
+    ):
         hosts_in_nmap_format = [{"ip": ip, "port": ""} for ip in self.alive_hosts]
         ssl_scan = NmapProcessingManager(
             hosts=hosts_in_nmap_format,
             arguments=f"-T4 -F -sC -sV --script=.{ssl_script_path} --version-intensity 1 --open --host-timeout={host_timeout}s",
-            workers=10
+            workers=10,
         )
         ssl_scan.start()
         scan_results = ssl_scan.get_results()
@@ -72,12 +80,12 @@ class TlsScanner:
                 ssl_cert = scripts.get("ssl-cert")
                 if not ssl_cert:
                     continue
-                if "Subject" in ssl_cert or "Issuer" in ssl_cert: 
+                if "Subject" in ssl_cert or "Issuer" in ssl_cert:
                     if self.tls_ports.get(host):
                         self.tls_ports[host].append(port)
                     else:
                         self.tls_ports[host] = [port]
-            if self.tls_ports.get(host):    
+            if self.tls_ports.get(host):
                 self.hosts[host].update({"tls_ports": self.tls_ports[host]})
 
     def link_alive_hosts_with_tls_ports(self):
@@ -98,46 +106,56 @@ class TlsScanner:
                     self.alive_hosts_with_ports[host] = 443
             else:
                 self.alive_hosts_with_ports[host] = 443
-    
-    def start_tls_scan(self,
-                       report_detail: str = DefaultTlsScannerValues.TLS_SCANNER_REPORT_DETAIL,
-                       scan_detail: str = DefaultTlsScannerValues.TLS_SCANNER_SCAN_DETAIL,
-                       scanner_path: str = DefaultTlsScannerValues.TLS_SCANNER_PATH,
-                       threads: int = DefaultTlsScannerValues.TLS_SCANNER_THREADS):
+
+    def start_tls_scan(
+        self,
+        report_detail: str = DefaultTlsScannerValues.TLS_SCANNER_REPORT_DETAIL,
+        scan_detail: str = DefaultTlsScannerValues.TLS_SCANNER_SCAN_DETAIL,
+        scanner_path: str = DefaultTlsScannerValues.TLS_SCANNER_PATH,
+        threads: int = DefaultTlsScannerValues.TLS_SCANNER_THREADS,
+    ):
         for host, port in self.alive_hosts_with_ports.items():
             print(f"Start tls scan for {host}")
             try:
-                command = ["java", 
-                        "-jar", 
-                        scanner_path, 
-                        "-connect",
-                        str(host) + ":" + str(port),
-                        "-noColor",
-                        "-implementation",
-                        "-reportDetail",
-                        report_detail,
-                        "-scanDetail",
-                        scan_detail,
-                        "-overallThreads",
-                        str(threads),
-                        "-parallelProbes",
-                        str(threads)]
-                tls_scanner_res = check_output(command, 
-                                               universal_newlines=True, 
-                                               timeout=DefaultTlsScannerValues.TLS_SCANNER_TIMEOUT, 
-                                               stderr=DEVNULL)
-                ansi_escape = compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
-                tls_scanner_res = ansi_escape.sub('', tls_scanner_res)
+                command = [
+                    "java",
+                    "-jar",
+                    scanner_path,
+                    "-connect",
+                    str(host) + ":" + str(port),
+                    "-noColor",
+                    "-implementation",
+                    "-reportDetail",
+                    report_detail,
+                    "-scanDetail",
+                    scan_detail,
+                    "-overallThreads",
+                    str(threads),
+                    "-parallelProbes",
+                    str(threads),
+                ]
+                tls_scanner_res = check_output(
+                    command,
+                    universal_newlines=True,
+                    timeout=DefaultTlsScannerValues.TLS_SCANNER_TIMEOUT,
+                    stderr=DEVNULL,
+                )
+                ansi_escape = compile(r"\x1B\[[0-?]*[ -/]*[@-~]")
+                tls_scanner_res = ansi_escape.sub("", tls_scanner_res)
             except:
                 continue
             vendor = self.hosts[host].get("vendor")
             product = self.hosts[host].get("product")
-            name_of_file = "{host}-{port}-{vendor}-{product}".format(host=host, port=str(port), vendor=vendor, product=product).replace(" ", "_")
-            self.save_tls_results(dest_dir=DefaultValues.RESULTS_DIRECTORY, 
-                                  sub_dir=DefaultTlsScannerValues.TLS_SCANNER_RESULTS_DIR,
-                                  filename=name_of_file, 
-                                  result=tls_scanner_res)
-    
+            name_of_file = "{host}-{port}-{vendor}-{product}".format(
+                host=host, port=str(port), vendor=vendor, product=product
+            ).replace(" ", "_")
+            self.save_tls_results(
+                dest_dir=DefaultValues.RESULTS_DIRECTORY,
+                sub_dir=DefaultTlsScannerValues.TLS_SCANNER_RESULTS_DIR,
+                filename=name_of_file,
+                result=tls_scanner_res,
+            )
+
     @create_results_directory()
     @create_subdirectory(subdirectory=DefaultTlsScannerValues.TLS_SCANNER_RESULTS_DIR)
     def save_tls_results(self, dest_dir: str, sub_dir: str, filename: str, result):

--- a/grinder/tlsscanner.py
+++ b/grinder/tlsscanner.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+from grinder.nmapprocessmanager import NmapProcessingManager
+from grinder.decorators import create_results_directory
+from grinder.defaultvalues import DefaultTlsScannerValues
+
+from nmap import PortScanner
+from pprint import pprint
+from itertools import zip_longest
+from random import choice
+from subprocess import check_output
+from re import compile
+
+
+class TlsScanner:
+    def __init__(self, hosts: dict, n: int = DefaultTlsScannerValues.LENGTH_OF_HOSTS_SUBGROUPS):
+        self.hosts: dict = hosts
+        self.alive_hosts: list = []
+        self.tls_ports: dict = {}
+        self.all_ports: dict = {}
+        self.alive_hosts_with_ports: dict = {}
+        self.n: int = n
+    
+    def _grouper(self, n, iterable, padding=None):
+        return zip_longest(*[iter(iterable)]*n, fillvalue=padding)
+
+    def _set_ping_status(self):
+        for ip, host_info in self.hosts.items():
+            if ip in self.alive_hosts:
+                host_info.update({"tls_status": "online"})
+            else:
+                host_info.update({"tls_status": "offline"})
+
+    def sort_alive_hosts(self):
+        nm = PortScanner()
+        hosts_ip = list(self.hosts.keys())
+        groups = self._grouper(self.n, hosts_ip)
+        groups = [list(group) for group in groups]
+        groups_len = len(groups)
+        for index, group in enumerate(groups):
+            print(f"Pingscan for group {str(index)}/{str(groups_len)}")
+            group_ips = [ip for ip in group if ip]
+            hosts_in_nmap_format = " ".join(group_ips)
+            nm.scan(hosts=hosts_in_nmap_format, 
+                    arguments=DefaultTlsScannerValues.NMAP_PING_SCAN_ARGS)
+            results = nm.all_hosts()
+            alive_hosts_group = [ip for ip in results if nm[ip]["status"]["state"] == "up"]
+            groups[index] = alive_hosts_group
+        groups_flat = [host for group in groups for host in group]
+        self.alive_hosts = groups_flat
+        self._set_ping_status()
+
+    def detect_tls_ports(self, 
+                         ssl_script_path: str = DefaultTlsScannerValues.SSL_NMAP_SCRIPT_PATH,
+                         host_timeout: int = DefaultTlsScannerValues.TLS_DETECTION_HOST_TIMEOUT):
+        hosts_in_nmap_format = [{"ip": ip, "port": ""} for ip in self.alive_hosts]
+        ssl_scan = NmapProcessingManager(
+            hosts=hosts_in_nmap_format,
+            arguments=f"-T4 -F -sC -sV --script=.{ssl_script_path} --version-intensity 1 --host-timeout={host_timeout}s",
+            workers=10
+        )
+        ssl_scan.start()
+        scan_results = ssl_scan.get_results()
+        for host, results in scan_results.items():
+            tcp = results.get("tcp")
+            if not tcp:
+                continue
+            self.all_ports[host] = list(tcp.keys())
+            for port, service in tcp.items():
+                scripts = service.get("script")
+                if not scripts:
+                    continue
+                ssl_cert = scripts.get("ssl-cert")
+                if not ssl_cert:
+                    continue
+                if "Subject" in ssl_cert or "Issuer" in ssl_cert: 
+                    if self.tls_ports.get(host):
+                        self.tls_ports[host].append(port)
+                    else:
+                        self.tls_ports[host] = [port]
+            if self.tls_ports.get(host):    
+                self.hosts[host].update({"tls_ports": self.tls_ports[host]})
+
+    def link_alive_hosts_with_tls_ports(self):
+        for host in self.alive_hosts:
+            if self.tls_ports.get(host):
+                if 443 in self.tls_ports[host]:
+                    self.alive_hosts_with_ports[host] = 443
+                elif 8443 in self.tls_ports[host]:
+                    self.alive_hosts_with_ports[host] = 8443
+                else:
+                    self.alive_hosts_with_ports[host] = choice(self.tls_ports[host])
+            elif self.all_ports.get(host):
+                if 443 in self.all_ports[host]:
+                    self.alive_hosts_with_ports[host] = 443
+                elif 8443 in self.all_ports[host]:
+                    self.alive_hosts_with_ports[host] = 8443
+                else:
+                    self.alive_hosts_with_ports[host] = 443
+            else:
+                self.alive_hosts_with_ports[host] = 443
+    
+    def start_tls_scan(self,
+                       report_detail: str = DefaultTlsScannerValues.TLS_SCANNER_REPORT_DETAIL,
+                       scan_detail: str = DefaultTlsScannerValues.TLS_SCANNER_SCAN_DETAIL,
+                       scanner_path: str = DefaultTlsScannerValues.TLS_SCANNER_PATH,
+                       threads: int = DefaultTlsScannerValues.TLS_SCANNER_THREADS):
+        for host, port in self.alive_hosts_with_ports.items():
+            print(f"Start tls scan for {host}")
+            try:
+                command = ["java", 
+                        "-jar", 
+                        scanner_path, 
+                        "-connect",
+                        str(host) + ":" + str(port),
+                        "-noColor",
+                        "-implementation",
+                        "-reportDetail",
+                        report_detail,
+                        "-scanDetail",
+                        scan_detail,
+                        "-overallThreads",
+                        str(threads),
+                        "-parallelProbes",
+                        str(threads)]
+                tls_scanner_res = check_output(command, universal_newlines=True, timeout=DefaultTlsScannerValues.TLS_SCANNER_TIMEOUT)
+                ansi_escape = compile(r'\x1B\[[0-?]*[ -/]*[@-~]')
+                tls_scanner_res = ansi_escape.sub('', tls_scanner_res)
+            except:
+                continue
+            vendor = self.hosts[host].get("vendor")
+            product = self.hosts[host].get("product")
+            name_of_file = "{host}-{port}-{vendor}-{product}".format(host=host, port=str(port), vendor=vendor, product=product).replace(" ", "_")
+            self.save_tls_results(dest_dir=DefaultTlsScannerValues.TLS_SCANNER_RESULTS_DIR, filename=name_of_file, result=tls_scanner_res)
+    
+    @create_results_directory()
+    def save_tls_results(self, dest_dir: str, filename: str, result):
+        with open(f"./{dest_dir}/{filename}.txt", mode="w") as result_file:
+            result_file.write(result)

--- a/grinder/tlsscanner.py
+++ b/grinder/tlsscanner.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 from grinder.nmapprocessmanager import NmapProcessingManager
-from grinder.decorators import create_results_directory, create_subdirectory, timer
+from grinder.decorators import create_results_directory, create_subdirectory, timer, exception_handler
 from grinder.defaultvalues import DefaultTlsScannerValues, DefaultValues
+from grinder.errors import GrinderCoreTlsScanner
 
 from nmap import PortScanner
 from pprint import pprint
@@ -111,6 +112,7 @@ class TlsScanner:
                 self.alive_hosts_with_ports[host] = 443
 
     @timer
+    @exception_handler(expected_exception=GrinderCoreTlsScanner)
     def _run_tls_on_host(
         self, scanner_path, host, port, report_detail, scan_detail, threads
     ):
@@ -168,7 +170,7 @@ class TlsScanner:
                     scan_detail=scan_detail,
                     threads=threads,
                 )
-            except:
+            except Exception:
                 continue
             vendor = self.hosts[host].get("vendor")
             product = self.hosts[host].get("product")

--- a/plugins/ssl-cert.nse
+++ b/plugins/ssl-cert.nse
@@ -1,0 +1,279 @@
+local nmap = require "nmap"
+local shortport = require "shortport"
+local sslcert = require "sslcert"
+local stdnse = require "stdnse"
+local string = require "string"
+local tls = require "tls"
+local unicode = require "unicode"
+
+description = [[
+Retrieves a server's SSL certificate. The amount of information printed
+about the certificate depends on the verbosity level. With no extra
+verbosity, the script prints the validity period and the commonName,
+organizationName, stateOrProvinceName, and countryName of the subject.
+
+<code>
+443/tcp open  https
+| ssl-cert: Subject: commonName=www.paypal.com/organizationName=PayPal, Inc.\
+/stateOrProvinceName=California/countryName=US
+| Not valid before: 2011-03-23 00:00:00
+|_Not valid after:  2013-04-01 23:59:59
+</code>
+
+With <code>-v</code> it adds the issuer name and fingerprints.
+
+<code>
+443/tcp open  https
+| ssl-cert: Subject: commonName=www.paypal.com/organizationName=PayPal, Inc.\
+/stateOrProvinceName=California/countryName=US
+| Issuer: commonName=VeriSign Class 3 Extended Validation SSL CA\
+/organizationName=VeriSign, Inc./countryName=US
+| Public Key type: rsa
+| Public Key bits: 2048
+| Signature Algorithm: sha1WithRSAEncryption
+| Not valid before: 2011-03-23 00:00:00
+| Not valid after:  2013-04-01 23:59:59
+| MD5:   bf47 ceca d861 efa7 7d14 88ad 4a73 cb5b
+|_SHA-1: d846 5221 467a 0d15 3df0 9f2e af6d 4390 0213 9a68
+</code>
+
+With <code>-vv</code> it adds the PEM-encoded contents of the entire
+certificate.
+
+<code>
+443/tcp open  https
+| ssl-cert: Subject: commonName=www.paypal.com/organizationName=PayPal, Inc.\
+/stateOrProvinceName=California/countryName=US/1.3.6.1.4.1.311.60.2.1.2=Delaware\
+/postalCode=95131-2021/localityName=San Jose/serialNumber=3014267\
+/streetAddress=2211 N 1st St/1.3.6.1.4.1.311.60.2.1.3=US\
+/organizationalUnitName=PayPal Production/businessCategory=Private Organization
+| Issuer: commonName=VeriSign Class 3 Extended Validation SSL CA\
+/organizationName=VeriSign, Inc./countryName=US\
+/organizationalUnitName=Terms of use at https://www.verisign.com/rpa (c)06
+| Public Key type: rsa
+| Public Key bits: 2048
+| Signature Algorithm: sha1WithRSAEncryption
+| Not valid before: 2011-03-23 00:00:00
+| Not valid after:  2013-04-01 23:59:59
+| MD5:   bf47 ceca d861 efa7 7d14 88ad 4a73 cb5b
+| SHA-1: d846 5221 467a 0d15 3df0 9f2e af6d 4390 0213 9a68
+| -----BEGIN CERTIFICATE-----
+| MIIGSzCCBTOgAwIBAgIQLjOHT2/i1B7T//819qTJGDANBgkqhkiG9w0BAQUFADCB
+...
+| 9YDR12XLZeQjO1uiunCsJkDIf9/5Mqpu57pw8v1QNA==
+|_-----END CERTIFICATE-----
+</code>
+]]
+
+---
+-- @output
+-- 443/tcp open  https
+-- | ssl-cert: Subject: commonName=www.paypal.com/organizationName=PayPal, Inc.\
+-- /stateOrProvinceName=California/countryName=US
+-- | Not valid before: 2011-03-23 00:00:00
+-- |_Not valid after:  2013-04-01 23:59:59
+--
+-- @xmloutput
+-- <table key="subject">
+--   <elem key="1.3.6.1.4.1.311.60.2.1.2">Delaware</elem>
+--   <elem key="1.3.6.1.4.1.311.60.2.1.3">US</elem>
+--   <elem key="postalCode">95131-2021</elem>
+--   <elem key="localityName">San Jose</elem>
+--   <elem key="serialNumber">3014267</elem>
+--   <elem key="countryName">US</elem>
+--   <elem key="stateOrProvinceName">California</elem>
+--   <elem key="streetAddress">2211 N 1st St</elem>
+--   <elem key="organizationalUnitName">PayPal Production</elem>
+--   <elem key="commonName">www.paypal.com</elem>
+--   <elem key="organizationName">PayPal, Inc.</elem>
+--   <elem key="businessCategory">Private Organization</elem>
+-- </table>
+-- <table key="issuer">
+--   <elem key="organizationalUnitName">Terms of use at https://www.verisign.com/rpa (c)06</elem>
+--   <elem key="organizationName">VeriSign, Inc.</elem>
+--   <elem key="commonName">VeriSign Class 3 Extended Validation SSL CA</elem>
+--   <elem key="countryName">US</elem>
+-- </table>
+-- <table key="pubkey">
+--   <elem key="type">rsa</elem>
+--   <elem key="bits">2048</elem>
+-- </table>
+-- <elem key="sig_algo">sha1WithRSAEncryption</elem>
+-- <table key="validity">
+--   <elem key="notBefore">2011-03-23T00:00:00+00:00</elem>
+--   <elem key="notAfter">2013-04-01T23:59:59+00:00</elem>
+-- </table>
+-- <elem key="md5">bf47cecad861efa77d1488ad4a73cb5b</elem>
+-- <elem key="sha1">d8465221467a0d153df09f2eaf6d439002139a68</elem>
+-- <elem key="pem">-----BEGIN CERTIFICATE-----
+-- MIIGSzCCBTOgAwIBAgIQLjOHT2/i1B7T//819qTJGDANBgkqhkiG9w0BAQUFADCB
+-- ...
+-- 9YDR12XLZeQjO1uiunCsJkDIf9/5Mqpu57pw8v1QNA==
+-- -----END CERTIFICATE-----
+-- </elem>
+
+author = "David Fifield"
+
+license = "Same as Nmap--See https://nmap.org/book/man-legal.html"
+
+categories = { "default", "safe", "discovery" }
+
+
+portrule = function(host, port)
+  return shortport.ssl(host, port) or sslcert.isPortSupported(port) or sslcert.getPrepareTLSWithoutReconnect(port)
+end
+
+-- Find the index of a value in an array.
+function table_find(t, value)
+  local i, v
+  for i, v in ipairs(t) do
+    if v == value then
+      return i
+    end
+  end
+  return nil
+end
+
+function date_to_string(date)
+  if not date then
+    return "MISSING"
+  end
+  if type(date) == "string" then
+    return string.format("Can't parse; string is \"%s\"", date)
+  else
+    return stdnse.format_timestamp(date)
+  end
+end
+
+-- These are the subject/issuer name fields that will be shown, in this order,
+-- without a high verbosity.
+local NON_VERBOSE_FIELDS = { "commonName", "organizationName",
+"stateOrProvinceName", "countryName" }
+
+-- Test to see if the string is UTF-16 and transcode it if possible
+local function maybe_decode(str)
+  -- If length is not even, then return as-is
+  if #str < 2 or #str % 2 == 1 then
+    return str
+  end
+  if str:byte(1) > 0 and str:byte(2) == 0 then
+    -- little-endian UTF-16
+    return unicode.transcode(str, unicode.utf16_dec, unicode.utf8_enc, false, nil)
+  elseif str:byte(1) == 0 and str:byte(2) > 0 then
+    -- big-endian UTF-16
+    return unicode.transcode(str, unicode.utf16_dec, unicode.utf8_enc, true, nil)
+  else
+    return str
+  end
+end
+
+function stringify_name(name)
+  local fields = {}
+  local _, k, v
+  if not name then
+    return nil
+  end
+  for _, k in ipairs(NON_VERBOSE_FIELDS) do
+    v = name[k]
+    if v then
+      fields[#fields + 1] = string.format("%s=%s", k, maybe_decode(v) or '')
+    end
+  end
+  if nmap.verbosity() > 1 then
+    for k, v in pairs(name) do
+      -- Don't include a field twice.
+      if not table_find(NON_VERBOSE_FIELDS, k) then
+        if type(k) == "table" then
+          k = stdnse.strjoin(".", k)
+        end
+        fields[#fields + 1] = string.format("%s=%s", k, maybe_decode(v) or '')
+      end
+    end
+  end
+  return stdnse.strjoin("/", fields)
+end
+
+local function name_to_table(name)
+  local output = {}
+  for k, v in pairs(name) do
+    if type(k) == "table" then
+      k = stdnse.strjoin(".", k)
+    end
+    output[k] = v
+  end
+  return output
+end
+
+local function output_tab(cert)
+  local o = stdnse.output_table()
+  o.subject = name_to_table(cert.subject)
+  o.issuer = name_to_table(cert.issuer)
+  o.pubkey = cert.pubkey
+  o.extensions = cert.extensions
+  o.sig_algo = cert.sig_algorithm
+  o.validity = {}
+  for k, v in pairs(cert.validity) do
+    if type(v)=="string" then
+      o.validity[k] = v
+    else
+      o.validity[k] = stdnse.format_timestamp(v)
+    end
+  end
+  o.md5 = stdnse.tohex(cert:digest("md5"))
+  o.sha1 = stdnse.tohex(cert:digest("sha1"))
+  o.pem = cert.pem
+  return o
+end
+
+local function output_str(cert)
+  local lines = {}
+
+  lines[#lines + 1] = "Subject: " .. stringify_name(cert.subject)
+  if cert.extensions then
+    for _, e in ipairs(cert.extensions) do
+      if e.name == "X509v3 Subject Alternative Name" then
+        lines[#lines + 1] = "Subject Alternative Name: " .. e.value
+        break
+      end
+    end
+  end
+
+  if nmap.verbosity() > 0 then
+    lines[#lines + 1] = "Issuer: " .. stringify_name(cert.issuer)
+  end
+
+  if nmap.verbosity() > 0 then
+    lines[#lines + 1] = "Public Key type: " .. cert.pubkey.type
+    lines[#lines + 1] = "Public Key bits: " .. cert.pubkey.bits
+    lines[#lines + 1] = "Signature Algorithm: " .. cert.sig_algorithm
+  end
+
+  lines[#lines + 1] = "Not valid before: " ..
+  date_to_string(cert.validity.notBefore)
+  lines[#lines + 1] = "Not valid after:  " ..
+  date_to_string(cert.validity.notAfter)
+
+  if nmap.verbosity() > 0 then
+    lines[#lines + 1] = "MD5:   " .. stdnse.tohex(cert:digest("md5"), { separator = " ", group = 4 })
+    lines[#lines + 1] = "SHA-1: " .. stdnse.tohex(cert:digest("sha1"), { separator = " ", group = 4 })
+  end
+
+  if nmap.verbosity() > 1 then
+    lines[#lines + 1] = cert.pem
+  end
+  return stdnse.strjoin("\n", lines)
+end
+
+action = function(host, port)
+  host.targetname = tls.servername(host)
+  local status, cert = sslcert.getCertificate(host, port)
+  if ( not(status) ) then
+    stdnse.debug1("getCertificate error: %s", cert or "unknown")
+    return
+  end
+
+  return output_tab(cert), output_str(cert)
+end
+
+
+


### PR DESCRIPTION
Currently, I'm working on the integration of TLS-Scanner/TLS-Attacker into Grinder as divided modules for TLS scanning. This work is divided into 4 parts:
1. Make preparational actions such as fast ping for hosts to get only online and currently active hosts (or we can get stuck on some hosts and just lost our scan time) (done)
2. Detect services and ports with SSL/TLS services with Nmap NSE scripts (done)
3. Write a python wrapper for TLS-Scanner/TLS-Attacker java-core to handle and control it with CLI-arguments from Grinder interface (50/50, almost done but need testing, refactoring etc.)
4. Write a python parser for TLS results to append it into final results as json, csv, txt, etc. (to do)