### PR TITLE
Add HTTP raw response grabber

### DIFF
--- a/custom_scripts/py_scripts/http_response_grabber/http_response_grabber.py
+++ b/custom_scripts/py_scripts/http_response_grabber/http_response_grabber.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+from requests import get
+from requests.exceptions import ConnectionError, ConnectTimeout, ContentDecodingError
+from requests_toolbelt.utils import dump
+
+
+def main(host_info: dict, timeout: int = 3) -> dict:
+    """
+    Get raw HTTP response as decoded bytes (headers + response body)
+    :param host_info: host information
+    :param timeout: host timeout
+    :return: dictionary with status and data
+    """
+    output = {"http_response": "", "status": "Success"}
+
+    try:
+        proto = "https" if host_info.get("port") in [443, 8443] else "http"
+        url = f"{proto}://{host_info.get('ip')}:{host_info.get('port')}"
+        response = get(url, verify=False, timeout=timeout)
+        response_dump = bytearray()
+        dump._dump_response_data(
+            response, prefixes=dump.PrefixSettings(b"", b""), bytearr=response_dump
+        )
+    except (TimeoutError, ConnectTimeout):
+        output.update({"status": "Timeout error was caught"})
+    except ConnectionError as connection_err:
+        output.update({"status": f"Connection error was caught: {str(connection_err)}"})
+    except ContentDecodingError as content_err:
+        output.update(
+            {"status": f"Content decoding error was caight: {str(content_err)}"}
+        )
+    except Exception as unexp_err:
+        output.update({"status": f"Unexpected error was caught: {str(unexp_err)}"})
+    else:
+        output.update({"http_response": response_dump.decode("utf-8")})
+    return output
+
+
+if __name__ == "__main__":
+    host_info = {"ip": "localhost", "port": 80}
+    print(main(host_info))

--- a/custom_scripts/py_scripts/http_response_grabber/requirements.txt
+++ b/custom_scripts/py_scripts/http_response_grabber/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2019.11.28
+chardet==3.0.4
+idna==2.9
+requests==2.23.0
+requests-toolbelt==0.9.1
+urllib3==1.25.8


### PR DESCRIPTION
Example result:
```json
{
    "py_script":{
        "http_response":"HTTP/1.1 200 OK\r\nDate: Mon, 23 Mar 2020 19:54:49 GMT\r\nServer: Apache\r\nSet-Cookie: gvc=928vr3325388894837865; expires=Sat, 22-Mar-2025 19:54:49 GMT; Max-Age=157680000; path=/; domain=fwdservice.com; HttpOnly\r\nntCoent-Length: 51\r\nKeep-Alive: timeout=5, max=128\r\nConnection: Keep-Alive\r\nContent-Type: text/html; charset=UTF-8\r\nCache-Control: private\r\nContent-Encoding: gzip\r\nContent-Length: 58\r\n\r\n<html><head></head><body><!-- vbe --></body></html>",
        "status":"Success"
    }
}
```